### PR TITLE
Fix: proper startup after docker and/or container restarts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -48,6 +48,9 @@ if [ "$1" = "import" ]; then
 fi
 
 if [ "$1" = "run" ]; then
+    # Clean /tmp
+    rm -rf /tmp/*
+
     # Initialize PostgreSQL and Apache
     CreatePostgressqlConfig
     service postgresql start

--- a/run.sh
+++ b/run.sh
@@ -50,6 +50,9 @@ fi
 if [ "$1" = "run" ]; then
     # Clean /tmp
     rm -rf /tmp/*
+    
+    # Fix postgres data privileges
+    chown postgres:postgres /var/lib/postgresql -R
 
     # Initialize PostgreSQL and Apache
     CreatePostgressqlConfig


### PR DESCRIPTION
Hey @Overv , when using this great 👏 image, I've encountered 2 problems when restarting it:
- apache randomly refuses to spin up, the `/tmp/httpd_shm*` files are in the way
- postgresql refuses to start because of privileges on `/httpd_shm*`, caused by mounting it as a volume

This is PR to fix them, you're welcome to merge it.

---
Deails:
When apache didn't start, it said:
```
[Tue Jun 18 07:10:18.486435 2019] [tile:error] [pid 66:tid 140454639643584] (17)File exists: Failed to create shared memory segment on file /tmp/httpd_shm.66
[Tue Jun 18 07:10:18.486600 2019] [:emerg] [pid 66:tid 140454639643584] AH00020: Configuration Failed, exiting
```

When PostgreSQL refused to spin up, it said:
```
Error: Config owner (postgres:101) and data owner (root:0) do not match, and config owner is not root
```