### PR TITLE
Fix openstreetmap-tiles-update-expire - libraries for trim_osc.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN echo "deb [ allow-insecure=yes ] http://apt.postgresql.org/pub/repos/apt/ bi
   osmosis \
   osmium-tool \
   cron \
-  python-psycopg2 python-shapely python-lxml \
+  python3-psycopg2 python3-shapely python3-lxml \
 && apt-get clean autoclean \
 && apt-get autoremove --yes \
 && rm -rf /var/lib/{apt,dpkg,cache,log}/

--- a/openstreetmap-tiles-update-expire
+++ b/openstreetmap-tiles-update-expire
@@ -150,7 +150,6 @@ fi
 
 if [ -f $TRIM_POLY_FILE ] ; then
   m_ok "filtering diff"
-  /var/lib/mod_tile/data.poly
   if ! $TRIM_BIN $TRIM_OPTIONS $TRIM_REGION_OPTIONS  -z $CHANGE_FILE $CHANGE_FILE 1>&2 2>> "$RUNLOG"; then
       m_error "Trim_osc error"
   fi


### PR DESCRIPTION
The `openstreetmap-tiles-update-expire` script blows up on missing `psycopg2` python library.
This is a fix.