### PR TITLE
README.md consistent indentation and error in docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ docker run \
     -v openstreetmap-data:/var/lib/postgresql/10/main \
     --shm-size="192m" \
     -d overv/openstreetmap-tile-server \
-    run \
+    run
 ```
 For too high values you may notice excessive CPU load and memory usage. It might be that you will have to experimentally find the best values for yourself.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ First create a Docker volume to hold the PostgreSQL database that will contain t
 Next, download an .osm.pbf extract from geofabrik.de for the region that you're interested in. You can then start importing it into PostgreSQL by running a container and mounting the file as `/data.osm.pbf`. For example:
 
 ```
-    docker run -v /absolute/path/to/luxembourg.osm.pbf:/data.osm.pbf \
-               -v openstreetmap-data:/var/lib/postgresql/10/main \
-               overv/openstreetmap-tile-server \
-               import
+docker run \
+    -v /absolute/path/to/luxembourg.osm.pbf:/data.osm.pbf \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    overv/openstreetmap-tile-server \
+    import
 ```
 
 If the container exits without errors, then your data has been successfully imported and you are now ready to run the tile server.
@@ -24,11 +25,12 @@ If the container exits without errors, then your data has been successfully impo
 If your import is an extract of the planet and has polygonal bounds associated with it, like those from geofabrik.de, then it is possible to set your server up for automatic updates. Make sure to reference both the OSM file and the polygon file during the import process to facilitate this:
 
 ```
-    docker run -v /absolute/path/to/luxembourg.osm.pbf:/data.osm.pbf \
-               -v /absolute/path/to/luxembourg.poly:/data.poly \
-               -v /openstreetmap-data:/var/lib/postgresql/10/main \
-               overv/openstreetmap-tile-server \
-               import
+docker run \
+    -v /absolute/path/to/luxembourg.osm.pbf:/data.osm.pbf \
+    -v /absolute/path/to/luxembourg.poly:/data.poly \
+    -v /openstreetmap-data:/var/lib/postgresql/10/main \
+    overv/openstreetmap-tile-server \
+    import
 ```
 
 Refer to the section *Automatic updating and tile expiry* to actually enable the updates.
@@ -38,10 +40,11 @@ Refer to the section *Automatic updating and tile expiry* to actually enable the
 Run the server like this:
 
 ```
-    docker run -p 80:80 \
-               -v openstreetmap-data:/var/lib/postgresql/10/main \
-               -d overv/openstreetmap-tile-server \
-               run
+docker run \
+    -p 80:80 \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    -d overv/openstreetmap-tile-server \
+    run
 ```
 
 Your tiles will now be available at `http://localhost:80/tile/{z}/{x}/{y}.png`. The demo map in `leaflet-demo.html` will then be available on `http://localhost:80`. Note that it will initially take quite a bit of time to render the larger tiles for the first time.
@@ -51,12 +54,13 @@ Your tiles will now be available at `http://localhost:80/tile/{z}/{x}/{y}.png`. 
 Tiles that have already been rendered will be stored in `/var/lib/mod_tile`. To make sure that this data survives container restarts, you should create another volume for it:
 
 ```
-    docker volume create openstreetmap-rendered-tiles
-    docker run -p 80:80 \
-               -v openstreetmap-data:/var/lib/postgresql/10/main \
-               -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
-               -d overv/openstreetmap-tile-server \
-               run
+docker volume create openstreetmap-rendered-tiles
+docker run \
+    -p 80:80 \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
+    -d overv/openstreetmap-tile-server \
+    run
 ```
 
 ### Enabling automatic updating (optional)
@@ -64,12 +68,13 @@ Tiles that have already been rendered will be stored in `/var/lib/mod_tile`. To 
 Given that you've specified both the OSM data and polygon as specified in the *Automatic updates* section during server setup, you can enable the updating process by setting the variable `UPDATES` to `enabled`:
 
 ```
-docker run -p 80:80 \
-           -v openstreetmap-data:/var/lib/postgresql/10/main \
-           -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
-           -d overv/openstreetmap-tile-server \
-           -e UPDATES=enabled \
-           run
+docker run \
+    -p 80:80 \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
+    -d overv/openstreetmap-tile-server \
+    -e UPDATES=enabled \
+    run
 ```
 
 This will enable a background process that automatically downloads changes from the OpenStreetMap server, filters them for the relevant region polygon you specified, updates the database and finally marks the affected tiles for rerendering.
@@ -82,14 +87,24 @@ Details for update procedure and invoked scripts can be found here [link](https:
 
 The import and tile serving processes use 4 threads by default, but this number can be changed by setting the `THREADS` environment variable. For example:
 ```
-    docker run -p 80:80 -e THREADS=24 -v openstreetmap-data:/var/lib/postgresql/10/main -d overv/openstreetmap-tile-server run
+docker run \
+    -p 80:80 \
+    -e THREADS=24 \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    -d overv/openstreetmap-tile-server \
+    run
 ```
 ### AUTOVACUUM
 
 The database use the autovacuum feature by default. This behavior can be changed with `AUTOVACUUM` environment variable. For example:
-
-    docker run -p 80:80 -e AUTOVACUUM=off -v openstreetmap-data:/var/lib/postgresql/10/main -d overv/openstreetmap-tile-server
-
+```
+docker run \
+    -p 80:80 \
+    -e AUTOVACUUM=off \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    -d overv/openstreetmap-tile-server \
+    run
+```
 ### Benchmarks
 
 You can find an example of the import performance to expect with this image on the [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Osm2pgsql/benchmarks#debian_9_.2F_openstreetmap-tile-server).
@@ -99,14 +114,19 @@ You can find an example of the import performance to expect with this image on t
 ### ERROR: could not resize shared memory segment / No space left on device
 
 If you encounter such entries in the log, it will mean that the default shared memory limit (64 MB) is too low for the container and it should be raised:
-
-    renderd[121]: ERROR: failed to render TILE ajt 2 0-3 0-3
-    renderd[121]: reason: Postgis Plugin: ERROR: could not resize shared memory segment "/PostgreSQL.790133961" to 12615680 bytes: ### No space left on device
-
+```
+renderd[121]: ERROR: failed to render TILE ajt 2 0-3 0-3
+renderd[121]: reason: Postgis Plugin: ERROR: could not resize shared memory segment "/PostgreSQL.790133961" to 12615680 bytes: ### No space left on device
+```
 To raise it use `--shm-size` parameter. For example:
-
-    docker run -p 80:80 -v openstreetmap-data:/var/lib/postgresql/10/main --shm-size="192m" -d overv/openstreetmap-tile-server run
-
+```
+docker run \
+    -p 80:80 \
+    -v openstreetmap-data:/var/lib/postgresql/10/main \
+    --shm-size="192m" \
+    -d overv/openstreetmap-tile-server \
+    run \
+```
 For too high values you may notice excessive CPU load and memory usage. It might be that you will have to experimentally find the best values for yourself.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Given that you've specified both the OSM data and polygon as specified in the *A
 ```
 docker run \
     -p 80:80 \
+    -e UPDATES=enabled \
     -v openstreetmap-data:/var/lib/postgresql/10/main \
     -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
     -d overv/openstreetmap-tile-server \
-    -e UPDATES=enabled \
     run
 ```
 


### PR DESCRIPTION
The syntax of the [docker run](https://docs.docker.com/engine/reference/run/) command goes:
> `docker run [OPTIONS] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]`

Therefore the `-e UPDATES=enabled` under "Enabling automatic updating" have to come before the image declaration.