### PR TITLE
use carto version 0.18.2 to solve carto conflicts / warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ WORKDIR /home/renderer/src
 RUN git clone https://github.com/gravitystorm/openstreetmap-carto.git
 WORKDIR /home/renderer/src/openstreetmap-carto
 USER root
-RUN npm install -g carto
+RUN npm install -g carto@0.18.2
 USER renderer
 RUN carto project.mml > mapnik.xml
 


### PR DESCRIPTION
the patch solves https://github.com/Overv/openstreetmap-tile-server/issues/70