### PR TITLE
Add CI for openstreetmap-tile-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ before_script:
 - docker pull gjacquenot/openstreetmap-tile-server || true
 script:
 - docker build --pull --cache-from gjacquenot/openstreetmap-tile-server --tag gjacquenot/openstreetmap-tile-server .
-- touch build && make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server test
+- docker volume create openstreetmap-data
+- docker run --rm -v openstreetmap-data:/var/lib/postgresql/12/main gjacquenot/openstreetmap-tile-server import
+- docker run --rm -v openstreetmap-data:/var/lib/postgresql/12/main -p 80:80 -d gjacquenot/openstreetmap-tile-server run
 - sleep 30
 - make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server stop
 after_script:
@@ -21,7 +23,7 @@ after_success:
 - if [[ "$TRAVIS_BRANCH" == "master" ]];
   then
   docker images ;
-  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ;
   docker push gjacquenot/openstreetmap-tile-server ;
   fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ after_script:
 after_success:
 - if [[ "$TRAVIS_BRANCH" == "master" ]];
   then
-  docker tag overv/openstreetmap-tile-server gjacquenot/openstreetmap-tile-server ;
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
   docker push gjacquenot/openstreetmap-tile-server ;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: required
+os: linux
+language: minimal
 services:
 - docker
 before_install:
@@ -6,7 +7,9 @@ before_install:
 before_script:
 - echo "Before script"
 script:
-- docker build -t osm .
+- make build
+- make test
+- make stop
 after_script:
 - docker images
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+services:
+- docker
+before_install:
+- echo "Before install"
+before_script:
+- echo "Before script"
+script:
+- docker build -t osm .
+after_script:
+- docker images
+after_success:
+- if [[ "$TRAVIS_BRANCH" == "master" ]]; then echo "One can push to image dockerhub" ; fi
+notifications:
+  email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 - docker pull gjacquenot/openstreetmap-tile-server || true
 script:
 - docker build --pull --cache-from gjacquenot/openstreetmap-tile-server --tag gjacquenot/openstreetmap-tile-server .
-- make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server test
+- touch build && make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server test
 - sleep 30
 - make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server stop
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ after_script:
 after_success:
 - if [[ "$TRAVIS_BRANCH" == "master" ]];
   then
+  docker images ;
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
   docker push gjacquenot/openstreetmap-tile-server ;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,26 @@ os: linux
 language: minimal
 services:
 - docker
+env:
+  global:
+  - DOCKER_USERNAME=gjacquenot
+  - secure: NvtIgByN0GmaSqNsTWFtAU8hKhtBqkScSkYMzlwImZaPa5aDfDyach/otae6Zp3dgWmlGR90ui5HrA+4V0DUvrdx3gODyycwzqF2CvoYtOPr6DC1SN5+xb1ty3toBKMlAJyXQRvwSO0oMkOvFRutC8HVBU8A6g+pO4+4pjpu4WfNLBBfWX5Gq4lVlOLZ4L5NH4Es+BNpdNNWVjZPkrdbU3UtjQIfV2bmAF9ws8GTSxi9+DfJT7Zmj4o9aZfAyfnZ8bdRdiEXUcn8Ilbk3rJwbxIq6IPfI0MmqKveHzpYjBrhQhEsr5cLdbhRI4zB235L+l/hzQDrld7+lVGWsZs60Pgw1xeFHH63J5kBT4Ibn3KOdMLyfEQqY2W3aODp3eU7Bkj/8J/s6rc+uBohGyJOM9muTL54OSfNDSb8q4M9Y4S9okSysZuuS6ry/sFn2kMasDYVYeOg+A9XscLj1JXGRL8/hImUuhRbWnyob1F+gbpH1lbgWIAtQ97bHWt4xJs+Fps4LdaXeUZNTb+FIXE9RRe+qbbHX4+ExIkrkFg3JUnmaS37J8XZJmVXw3panv2DuGV2ri1u1DCa1/JpPmB6AbQIL1jfC7FmuqgMbRGg/6U2h5kAAga8gbyEZscMA1DyFhsqgIG/k87oqRiUumvJ9+/m+o9/EV+XvDLjgHzGMvA=
 before_install:
 - echo "Before install"
 before_script:
-- echo "Before script"
+- docker pull gjacquenot/openstreetmap-tile-server || true
 script:
-- make build
-- make test
-- make stop
+- docker build --pull --cache-from gjacquenot/openstreetmap-tile-server --tag gjacquenot/openstreetmap-tile-server .
+- make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server test
+- sleep 30
+- make DOCKER_IMAGE=gjacquenot/openstreetmap-tile-server stop
 after_script:
 - docker images
 after_success:
-- if [[ "$TRAVIS_BRANCH" == "master" ]]; then echo "One can push to image dockerhub" ; fi
+- if [[ "$TRAVIS_BRANCH" == "master" ]];
+  then
+  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
+  docker push gjacquenot/openstreetmap-tile-server ;
+  fi
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ after_script:
 after_success:
 - if [[ "$TRAVIS_BRANCH" == "master" ]];
   then
+  docker tag overv/openstreetmap-tile-server gjacquenot/openstreetmap-tile-server ;
   docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
   docker push gjacquenot/openstreetmap-tile-server ;
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,12 +144,12 @@ USER renderer
 # Configure Apache
 USER root
 RUN mkdir /var/lib/mod_tile \
-  && chown renderer /var/lib/mod_tile \
-  && mkdir /var/run/renderd \
-  && chown renderer /var/run/renderd
-RUN echo "LoadModule tile_module /usr/lib/apache2/modules/mod_tile.so" >> /etc/apache2/conf-available/mod_tile.conf \
-    && echo "LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so" >> /etc/apache2/conf-available/mod_headers.conf \
-  && a2enconf mod_tile && a2enconf mod_headers
+ && chown renderer /var/lib/mod_tile \
+ && mkdir /var/run/renderd \
+ && chown renderer /var/run/renderd \
+ && echo "LoadModule tile_module /usr/lib/apache2/modules/mod_tile.so" >> /etc/apache2/conf-available/mod_tile.conf \
+ && echo "LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so" >> /etc/apache2/conf-available/mod_headers.conf \
+ && a2enconf mod_tile && a2enconf mod_headers
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
 COPY leaflet-demo.html /var/www/html/index.html
 RUN ln -sf /dev/stdout /var/log/apache2/access.log \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ RUN apt-get update \
   autoconf \
   build-essential \
   bzip2 \
+  clang \
   cmake \
+  cron \
   fonts-noto-cjk \
   fonts-noto-hinted \
   fonts-noto-unhinted \
-  clang \
   gcc \
   gdal-bin \
-  make \
   git-core \
   libagg-dev \
   libboost-all-dev \
@@ -56,22 +56,23 @@ RUN apt-get update \
   mapnik-utils \
   nodejs \
   npm \
+  osmium-tool \
+  osmosis \
   postgis \
   postgresql-12 \
-  postgresql-server-dev-12 \
   postgresql-contrib-12 \
+  postgresql-server-dev-12 \
   protobuf-c-compiler \
   python-mapnik \
+  python3-lxml \
+  python3-psycopg2 \
+  python3-shapely \
   sudo \
   tar \
   ttf-unifont \
   unzip \
   wget \
   zlib1g-dev \
-  osmosis \
-  osmium-tool \
-  cron \
-  python3-psycopg2 python3-shapely python3-lxml \
 && apt-get clean autoclean \
 && apt-get autoremove --yes \
 && rm -rf /var/lib/{apt,dpkg,cache,log}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,9 +158,9 @@ RUN ln -sf /dev/stdout /var/log/apache2/access.log \
 # Configure PosgtreSQL
 COPY postgresql.custom.conf.tmpl /etc/postgresql/12/main/
 RUN chown -R postgres:postgres /var/lib/postgresql \
-  && chown postgres:postgres /etc/postgresql/12/main/postgresql.custom.conf.tmpl
-RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/12/main/pg_hba.conf \
-      && echo "host all all ::/0 md5" >> /etc/postgresql/12/main/pg_hba.conf
+ && chown postgres:postgres /etc/postgresql/12/main/postgresql.custom.conf.tmpl \
+ && echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/12/main/pg_hba.conf \
+ && echo "host all all ::/0 md5" >> /etc/postgresql/12/main/pg_hba.conf
 
 # copy update scripts
 COPY openstreetmap-tiles-update-expire /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,11 +158,12 @@ RUN chmod +x /usr/bin/openstreetmap-tiles-update-expire \
  && echo "*  *    * * *   renderer    openstreetmap-tiles-update-expire\n" >> /etc/crontab
 
 # install trim_osc.py helper script
-RUN cd ~/src \
+RUN mkdir -p /home/renderer/src \
+ && cd /home/renderer/src \
  && git clone https://github.com/zverik/regional \
  && cd regional \
  && git checkout 612fe3e040d8bb70d2ab3b133f3b2cfc6c940520 \
- && chmod u+x ~/src/regional/trim_osc.py
+ && chmod u+x /home/renderer/src/regional/trim_osc.py
 
 # Start running
 COPY run.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,10 +165,10 @@ RUN chown -R postgres:postgres /var/lib/postgresql \
 # copy update scripts
 COPY openstreetmap-tiles-update-expire /usr/bin/
 RUN chmod +x /usr/bin/openstreetmap-tiles-update-expire \
-    && mkdir /var/log/tiles \
-    && chmod a+rw /var/log/tiles \
-    && ln -s /home/renderer/src/mod_tile/osmosis-db_replag /usr/bin/osmosis-db_replag \
-    && echo "*  *    * * *   renderer    openstreetmap-tiles-update-expire\n" >> /etc/crontab
+ && mkdir /var/log/tiles \
+ && chmod a+rw /var/log/tiles \
+ && ln -s /home/renderer/src/mod_tile/osmosis-db_replag /usr/bin/osmosis-db_replag \
+ && echo "*  *    * * *   renderer    openstreetmap-tiles-update-expire\n" >> /etc/crontab
 
 # install trim_osc.py helper script
 USER renderer

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN mkdir /var/lib/mod_tile \
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
 COPY leaflet-demo.html /var/www/html/index.html
 RUN ln -sf /dev/stdout /var/log/apache2/access.log \
-  && ln -sf /dev/stderr /var/log/apache2/error.log
+ && ln -sf /dev/stderr /var/log/apache2/error.log
 
 # Configure PosgtreSQL
 COPY postgresql.custom.conf.tmpl /etc/postgresql/12/main/
@@ -148,7 +148,7 @@ RUN chown -R postgres:postgres /var/lib/postgresql \
  && echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/12/main/pg_hba.conf \
  && echo "host all all ::/0 md5" >> /etc/postgresql/12/main/pg_hba.conf
 
-# copy update scripts
+# Copy update scripts
 COPY openstreetmap-tiles-update-expire /usr/bin/
 RUN chmod +x /usr/bin/openstreetmap-tiles-update-expire \
  && mkdir /var/log/tiles \
@@ -156,12 +156,13 @@ RUN chmod +x /usr/bin/openstreetmap-tiles-update-expire \
  && ln -s /home/renderer/src/mod_tile/osmosis-db_replag /usr/bin/osmosis-db_replag \
  && echo "*  *    * * *   renderer    openstreetmap-tiles-update-expire\n" >> /etc/crontab
 
-# install trim_osc.py helper script
+# Install trim_osc.py helper script
 RUN mkdir -p /home/renderer/src \
  && cd /home/renderer/src \
  && git clone https://github.com/zverik/regional \
  && cd regional \
  && git checkout 612fe3e040d8bb70d2ab3b133f3b2cfc6c940520 \
+ && rm -rf .git \
  && chmod u+x /home/renderer/src/regional/trim_osc.py
 
 # Start running

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,7 @@ RUN mkdir -p /home/renderer/src \
  && make -j $(nproc) install \
  && make -j $(nproc) install-mod_tile \
  && ldconfig \
- && cd .. \
- && rm -rf mod_tile
+ && cd ..
 
 # Configure stylesheet
 RUN mkdir -p /home/renderer/src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,10 +173,10 @@ RUN chmod +x /usr/bin/openstreetmap-tiles-update-expire \
 # install trim_osc.py helper script
 USER renderer
 RUN cd ~/src \
-    && git clone https://github.com/zverik/regional \
-    && cd regional \
-    && git checkout 612fe3e040d8bb70d2ab3b133f3b2cfc6c940520 \
-    && chmod u+x ~/src/regional/trim_osc.py
+ && git clone https://github.com/zverik/regional \
+ && cd regional \
+ && git checkout 612fe3e040d8bb70d2ab3b133f3b2cfc6c940520 \
+ && chmod u+x ~/src/regional/trim_osc.py
 
 # Start running
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,7 @@ RUN mkdir -p /home/renderer/src \
  && git clone https://github.com/gravitystorm/openstreetmap-carto.git \
  && git -C openstreetmap-carto checkout v4.23.0 \
  && cd openstreetmap-carto \
+ && rm -rf .git \
  && npm install -g carto@0.18.2 \
  && carto project.mml > mapnik.xml \
  && scripts/get-shapefiles.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN mkdir -p /home/renderer/src \
  && make install \
  && mkdir /nodes \
  && chown renderer:renderer /nodes \
- && rm -rf /home/renderer/src/osm2pgsql/build
+ && rm -rf /home/renderer/src/osm2pgsql
 
 # Install mod_tile and renderd
 RUN mkdir -p /home/renderer/src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,18 +91,18 @@ RUN adduser --disabled-password --gecos "" renderer
 USER renderer
 
 # Install latest osm2pgsql
-RUN mkdir /home/renderer/src
-WORKDIR /home/renderer/src
-RUN git clone https://github.com/openstreetmap/osm2pgsql.git
-WORKDIR /home/renderer/src/osm2pgsql
-RUN mkdir build
-WORKDIR /home/renderer/src/osm2pgsql/build
-RUN cmake .. \
-  && make -j $(nproc)
-USER root
-RUN make install
-RUN mkdir /nodes \
-    && chown renderer:renderer /nodes
+RUN mkdir -p /home/renderer/src \
+ && cd /home/renderer/src \
+ && git clone https://github.com/openstreetmap/osm2pgsql.git \
+ && cd /home/renderer/src/osm2pgsql \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make -j $(nproc) \
+ && make install \
+ && mkdir /nodes \
+ && chown renderer:renderer /nodes \
+ && rm -rf /home/renderer/src
 USER renderer
 
 # Install and test Mapnik

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update \
   autoconf \
   build-essential \
   bzip2 \
-  clang \
   cmake \
   cron \
   fonts-noto-cjk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,13 @@ RUN apt-get update \
 && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Set up PostGIS
-RUN wget http://download.osgeo.org/postgis/source/postgis-3.0.0rc2.tar.gz
-RUN tar -xvzf postgis-3.0.0rc2.tar.gz
-RUN cd postgis-3.0.0rc2 && ./configure && make && make install
+RUN wget http://download.osgeo.org/postgis/source/postgis-3.0.0rc2.tar.gz -O postgis.tar.gz \
+ && mkdir -p postgis_src \
+ && tar -xvzf postgis.tar.gz --strip 1 -C postgis_src \
+ && rm postgis.tar.gz \
+ && cd postgis_src \
+ && ./configure && make && make install \
+ && cd .. && rm -rf postgis_src
 
 # Set up renderer user
 RUN adduser --disabled-password --gecos "" renderer

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update \
 && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Set up PostGIS
-RUN wget http://download.osgeo.org/postgis/source/postgis-3.0.0rc2.tar.gz -O postgis.tar.gz \
+RUN wget http://download.osgeo.org/postgis/source/postgis-3.0.0.tar.gz -O postgis.tar.gz \
  && mkdir -p postgis_src \
  && tar -xvzf postgis.tar.gz --strip 1 -C postgis_src \
  && rm postgis.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,16 +109,17 @@ USER renderer
 RUN python -c 'import mapnik'
 
 # Install mod_tile and renderd
-WORKDIR /home/renderer/src
-RUN git clone -b switch2osm https://github.com/SomeoneElseOSM/mod_tile.git
-WORKDIR /home/renderer/src/mod_tile
-RUN ./autogen.sh \
-  && ./configure \
-  && make -j $(nproc)
-USER root
-RUN make -j $(nproc) install \
-  && make -j $(nproc) install-mod_tile \
-  && ldconfig
+RUN mkdir -p /home/renderer/src \
+ && git clone -b switch2osm https://github.com/SomeoneElseOSM/mod_tile.git \
+ && cd mod_tile \
+ && ./autogen.sh \
+ && ./configure \
+ && make -j $(nproc) \
+ && make -j $(nproc) install \
+ && make -j $(nproc) install-mod_tile \
+ && ldconfig \
+ && cd .. \
+ && rm -rf mod_tile
 USER renderer
 
 # Configure stylesheet

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN mkdir -p /home/renderer/src \
  && cd /home/renderer/src \
  && git clone https://github.com/openstreetmap/osm2pgsql.git \
  && cd /home/renderer/src/osm2pgsql \
+ && rm -rf .git \
  && mkdir build \
  && cd build \
  && cmake .. \
@@ -100,10 +101,11 @@ RUN mkdir -p /home/renderer/src \
  && make install \
  && mkdir /nodes \
  && chown renderer:renderer /nodes \
- && rm -rf /home/renderer/src
+ && rm -rf /home/renderer/src/osm2pgsql/build
 
 # Install mod_tile and renderd
 RUN mkdir -p /home/renderer/src \
+ && cd /home/renderer/src \
  && git clone -b switch2osm https://github.com/SomeoneElseOSM/mod_tile.git \
  && cd mod_tile \
  && ./autogen.sh \
@@ -117,6 +119,7 @@ RUN mkdir -p /home/renderer/src \
 
 # Configure stylesheet
 RUN mkdir -p /home/renderer/src \
+ && cd /home/renderer/src \
  && git clone https://github.com/gravitystorm/openstreetmap-carto.git \
  && git -C openstreetmap-carto checkout v4.23.0 \
  && cd openstreetmap-carto \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update \
   postgresql-contrib-12 \
   postgresql-server-dev-12 \
   protobuf-c-compiler \
-  python-mapnik \
+  python3-mapnik \
   python3-lxml \
   python3-psycopg2 \
   python3-shapely \

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,12 +123,11 @@ RUN mkdir -p /home/renderer/src \
 USER renderer
 
 # Configure stylesheet
-WORKDIR /home/renderer/src
-RUN git clone https://github.com/gravitystorm/openstreetmap-carto.git \
- && git -C openstreetmap-carto checkout v4.23.0
-WORKDIR /home/renderer/src/openstreetmap-carto
-USER root
-RUN npm install -g carto@0.18.2
+RUN mkdir -p /home/renderer/src \
+ && git clone https://github.com/gravitystorm/openstreetmap-carto.git \
+ && git -C openstreetmap-carto checkout v4.23.0 \
+ && openstreetmap-carto \
+ && npm install -g carto@0.18.2
 USER renderer
 RUN carto project.mml > mapnik.xml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update \
   gdal-bin \
   git-core \
   libagg-dev \
-  libboost-all-dev \
+  libboost-filesystem-dev \
+  libboost-system-dev \
   libbz2-dev \
   libcairo-dev \
   libcairomm-1.0-dev \

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 .PHONY: build push test
 
+DOCKER_IMAGE=overv/openstreetmap-tile-server
+
 build:
-	docker build -t overv/openstreetmap-tile-server .
+	docker build -t ${DOCKER_IMAGE} .
 
 push: build
-	docker push overv/openstreetmap-tile-server:latest
+	docker push ${DOCKER_IMAGE}:latest
 
 test: build
 	docker volume create openstreetmap-data
-	docker run -v openstreetmap-data:/var/lib/postgresql/12/main overv/openstreetmap-tile-server import
-	docker run -v openstreetmap-data:/var/lib/postgresql/12/main -p 80:80 -d overv/openstreetmap-tile-server run
+	docker run --rm -v openstreetmap-data:/var/lib/postgresql/12/main ${DOCKER_IMAGE} import
+	docker run --rm -v openstreetmap-data:/var/lib/postgresql/12/main -p 80:80 -d ${DOCKER_IMAGE} run
+
+stop:
+	docker rm -f `docker ps | grep '${DOCKER_IMAGE}' | awk '{ print $$1 }'` || true
+	docker volume rm -f openstreetmap-data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # openstreetmap-tile-server
 
+[![Build Status](https://travis-ci.org/Gjacquenot/openstreetmap-tile-server.svg?branch=master)](https://travis-ci.org/Gjacquenot/openstreetmap-tile-server)
+
+[![](https://images.microbadger.com/badges/image/gjacquenot/openstreetmap-tile-server.svg)](https://microbadger.com/images/gjacquenot/openstreetmap-tile-server "openstreetmap-tile-server")
+
 This container allows you to easily set up an OpenStreetMap PNG tile server given a `.osm.pbf` file. It is based on the [latest Ubuntu 18.04 LTS guide](https://switch2osm.org/manually-building-a-tile-server-18-04-lts/) from [switch2osm.org](https://switch2osm.org/) and therefore uses the default OpenStreetMap style.
 
 ## Setting up the server


### PR DESCRIPTION
This PR:

- simplifies and homogenizes the Dockerfile
- reduces the final image size (from 4.7Gb to 3.88Gb)
- adds continuous integration with .travis.yml that deploy the container on dockerhub
- adds badges in main Readme.md (path will have to be updated to match this repo)
- upgrade postgis from 3.0.0rc2 to 3.0.0

To use continuous integration with travis, one will have to create a travis account, update the .travis.yml (replace `jacquenot` with `overv`, replace the DOCKER_PASSWORD)

One could reduce significantly the container size using intermediate container, so that we do not have an unneeded compiler at runtime.

Result of CI can be seen [here](https://travis-ci.org/Gjacquenot/openstreetmap-tile-server/builds/628915047)
