### PR TITLE
Remove unnecessary shapefile archives to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,8 @@ RUN mkdir -p /home/renderer/src \
  && rm -rf .git \
  && npm install -g carto@0.18.2 \
  && carto project.mml > mapnik.xml \
- && scripts/get-shapefiles.py
+ && scripts/get-shapefiles.py \
+ && rm /home/renderer/src/openstreetmap-carto/data/*.zip
 
 # Configure renderd
 RUN sed -i 's/renderaccount/renderer/g' /usr/local/etc/renderd.conf \


### PR DESCRIPTION
Removing the shapefile zip files after unzipping at 
`/home/renderer/src/openstreetmap-carto/data/`
in stylesheet configuration layer reduces the final image size substantially from:

`osm_no_rm           latest              4a9f143cadb0        43 minutes ago      3.93GB`
to:
`osm_rm              latest              868e1b057c5b        35 minutes ago      3.16GB`

