### PR TITLE
Get nodejs from source because of apt package conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,13 @@ RUN apt-get update \
   && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && echo "deb [ trusted=yes ] http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
   && apt-get update \
-  && apt-get install -y apt-transport-https ca-certificates \
-  && apt-get install -y --no-install-recommends --allow-unauthenticated \
+  && apt-get install -y apt-transport-https ca-certificates 
+
+RUN apt-get install -y curl \
+  && wget --quiet -O - https://deb.nodesource.com/setup_10.x | bash - \
+  && apt-get install -y nodejs
+
+RUN apt-get install -y --no-install-recommends --allow-unauthenticated \
   apache2 \
   apache2-dev \
   autoconf \
@@ -54,8 +59,7 @@ RUN apt-get update \
   lua5.3 \
   make \
   mapnik-utils \
-  nodejs \
-  npm \
+  node-gyp \
   osmium-tool \
   osmosis \
   postgis \


### PR DESCRIPTION
**What?**
Install nodejs and npm from source instead of Ubuntu repository.

**Why?**
Newest packages (libmysqlclient-dev amongst other things, requested by libgdal-dev) in Ubuntu repository compile against libssl-dev (OpenSSL 1.1), but nodejs package is still depending on libssl1.0-dev which leads to a conflicting package situation (regarding the *-dev packages) and so apt is unable to install all requested packages.

Changing nodejs to original source package resolves this conflict and image builds without issues.

**Background info:**
https://bugs.launchpad.net/ubuntu/+source/mysql-5.7/+bug/1861304