### PR TITLE
fix configuration values inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ This will enable a background process that automatically downloads changes from 
 
 ### Cross-origin resource sharing
 
-To enable the `Access-Control-Allow-Origin` header to be able to retrieve tiles from other domains, simply set the `ALLOW_CORS` variable to `1`:
+To enable the `Access-Control-Allow-Origin` header to be able to retrieve tiles from other domains, simply set the `ALLOW_CORS` variable to `enabled`:
 
 ```
 docker run \
     -p 8080:80 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -e ALLOW_CORS=1 \
+    -e ALLOW_CORS=enabled \
     -d overv/openstreetmap-tile-server \
     run
 ```

--- a/run.sh
+++ b/run.sh
@@ -79,7 +79,7 @@ if [ "$1" = "run" ]; then
     chown postgres:postgres /var/lib/postgresql -R
 
     # Configure Apache CORS
-    if [ "$ALLOW_CORS" == "1" ]; then
+    if [ "$ALLOW_CORS" == "enabled" ]; then
         echo "export APACHE_ARGUMENTS='-D ALLOW_CORS'" >> /etc/apache2/envvars
     fi
 


### PR DESCRIPTION
Currently there are two configuration variables ALLOW_CORS and UPDATES. Both are boolean flags. One accept only value ‘enabled’ and another accepts only value ‘1’. It is inconsistent. 