### PR TITLE
Update README.md with `latest` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run \
     -v /absolute/path/to/luxembourg.osm.pbf:/data.osm.pbf \
     -v /absolute/path/to/luxembourg.poly:/data.poly \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    overv/openstreetmap-tile-server \
+    overv/openstreetmap-tile-server:latest \
     import
 ```
 
@@ -47,7 +47,7 @@ docker run \
     -e DOWNLOAD_PBF=http://download.geofabrik.de/europe/luxembourg-latest.osm.pbf \
     -e DOWNLOAD_POLY=http://download.geofabrik.de/europe/luxembourg.poly \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    overv/openstreetmap-tile-server \
+    overv/openstreetmap-tile-server:latest \
     import
 ```
 
@@ -59,7 +59,7 @@ Run the server like this:
 docker run \
     -p 8080:80 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -79,7 +79,7 @@ docker run \
     -p 8080:80 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
     -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -95,7 +95,7 @@ docker run \
     -e UPDATES=enabled \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
     -v openstreetmap-rendered-tiles:/var/lib/mod_tile \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -110,7 +110,7 @@ docker run \
     -p 8080:80 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
     -e ALLOW_CORS=enabled \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -123,7 +123,7 @@ docker run \
     -p 8080:80 \
     -p 5432:5432 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -141,7 +141,7 @@ docker run \
     -p 5432:5432 \
     -e PGPASSWORD=secret \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -157,7 +157,7 @@ docker run \
     -p 8080:80 \
     -e THREADS=24 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -169,7 +169,7 @@ docker run \
     -p 8080:80 \
     -e "OSM2PGSQL_EXTRA_ARGS=-C 4096" \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -181,7 +181,7 @@ docker run \
     -p 8080:80 \
     -e AUTOVACUUM=off \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 
@@ -195,7 +195,7 @@ docker run \
     -v openstreetmap-nodes:/nodes \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
     -e "OSM2PGSQL_EXTRA_ARGS=--flat-nodes /nodes/flat_nodes.bin" \
-    overv/openstreetmap-tile-server \
+    overv/openstreetmap-tile-server:latest \
     import
 ```
 
@@ -220,7 +220,7 @@ docker run \
     -p 8080:80 \
     -v openstreetmap-data:/var/lib/postgresql/12/main \
     --shm-size="192m" \
-    -d overv/openstreetmap-tile-server \
+    -d overv/openstreetmap-tile-server:latest \
     run
 ```
 For too high values you may notice excessive CPU load and memory usage. It might be that you will have to experimentally find the best values for yourself.


### PR DESCRIPTION
Currently if you pull the image and build the containers with auto-download for Luxembourg, it will do the process for all versions of containers. This creates an enormous amount of bloat and takes way longer.

Below examples were done running `docker system prune -a` and verified to make sure there were no other containers or images before each run:

Before change, after building Luxembourg (took me 35 minutes):

```
(base) isaac@ib-laptop:~$ docker system df
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              14                  1                   27.96GB             27.92GB (99%)
Containers          1                   1                   7.93kB              0B (0%)
Local Volumes       33                  1                   4.121GB             2.111GB (51%)
Build Cache         0                   0                   0B                  0B
```
After change, after building Luxembourg (took me 5 minutes):

```
(base) isaac@ib-laptop:~$ docker system df
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              1                   1                   3.201GB             0B (0%)
Containers          1                   1                   12.5kB              0B (0%)
Local Volumes       33                  1                   3.854GB             2.111GB (54%)
Build Cache         0                   0                   0B                  0B
```
