### PR TITLE
Fix font_dir of mapnik

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,7 @@ RUN mkdir -p /home/renderer/src \
 
 # Configure renderd
 RUN sed -i 's/renderaccount/renderer/g' /usr/local/etc/renderd.conf \
+ && sed -i 's/\/truetype//g' /usr/local/etc/renderd.conf \
  && sed -i 's/hot/tile/g' /usr/local/etc/renderd.conf
 
 # Configure Apache


### PR DESCRIPTION
OpenType fonts (OTF) are located in `/usr/share/fonts/opentype`,
however, the font_dir of mapnik is `/usr/share/fonts/truetype` and
mapnik is support OTF, it will cause mapnik can't find the OTFs
(OTFs are used by openstreetmap-carto, e.g., Noto CJK JP).

before: `font_dir=/usr/share/fonts/truetype`
after sed command: `font_dir=/usr/share/fonts`