### PR TITLE
Upgrade to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Based on
 # https://switch2osm.org/serving-tiles/manually-building-a-tile-server-18-04-lts/
@@ -43,20 +43,18 @@ RUN apt-get install -y --no-install-recommends \
   libgdal-dev \
   libgeos++-dev \
   libgeos-dev \
-  libgeotiff-epsg \
   libicu-dev \
   liblua5.3-dev \
   libmapnik-dev \
   libpq-dev \
   libproj-dev \
-  libprotobuf-c0-dev \
+  libprotobuf-c-dev \
   libtiff5-dev \
   libtool \
   libxml2-dev \
   lua5.3 \
   make \
   mapnik-utils \
-  node-gyp \
   osmium-tool \
   osmosis \
   postgis \


### PR DESCRIPTION
It seems like this should cover the upgrade to Ubuntu 20.04 at least. I haven't looked at updating any other software yet. I removed the packages that weren't installable anymore, but I'm not sure what if there's still something left that depends on them. I also added an explicit Python 2 installation for `scripts/get-shapefiles.py`.

@Istador Do you think there is anything else that needs to be done?