### PR TITLE
Update carto style to 5.3.1 and shapefile script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,12 +122,12 @@ RUN mkdir -p /home/renderer/src \
 # Configure stylesheet
 RUN mkdir -p /home/renderer/src \
  && cd /home/renderer/src \
- && git clone --single-branch --branch v5.2.0 https://github.com/gravitystorm/openstreetmap-carto.git --depth 1 \
+ && git clone --single-branch --branch v5.3.1 https://github.com/gravitystorm/openstreetmap-carto.git --depth 1 \
  && cd openstreetmap-carto \
  && rm -rf .git \
  && npm install -g carto@0.18.2 \
  && carto project.mml > mapnik.xml \
- && scripts/get-shapefiles.py \
+ && scripts/get-external-data.py \
  && rm /home/renderer/src/openstreetmap-carto/data/*.zip
 
 # Configure renderd


### PR DESCRIPTION
Update to 5.3.1 carto style relase.
With that change https://github.com/gravitystorm/openstreetmap-carto/pull/4092 shapefiles script changed file name and it needs to be updated in Dockerfile as well to update to latest carto style version.