### PR TITLE
Update NodeJS to 14 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
   && apt-get install -y wget gnupg2 lsb-core apt-transport-https ca-certificates curl \
   && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && echo "deb [ trusted=yes ] https://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
-  && wget --quiet -O - https://deb.nodesource.com/setup_10.x | bash - \
+  && wget --quiet -O - https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get update \
   && apt-get install -y nodejs
 


### PR DESCRIPTION
While testing #183 I noticed a deprecation warning for NodeJS and updated the version. It doesn't appear to cause any compatibility problems.