### PR TITLE
Fix index to match osm carto 5.3.1

### DIFF
--- a/indexes.sql
+++ b/indexes.sql
@@ -32,7 +32,7 @@ CREATE INDEX planet_osm_polygon_nobuilding
   ON planet_osm_polygon USING GIST (way)
   WHERE building IS NULL;
 CREATE INDEX planet_osm_polygon_name
-  ON planet_osm_polygon USING GIST (way)
+  ON planet_osm_polygon USING GIST (ST_PointOnSurface(way))
   WHERE name IS NOT NULL;
 CREATE INDEX planet_osm_polygon_way_area_z10
   ON planet_osm_polygon USING GIST (way)


### PR DESCRIPTION
The index currently in indexes.sql matches osm carto 4.23.0 but has a very bad performance with osm carto 5.3.1.

I ran into this issue when I used the tileserver docker image in version v1.7.1 to setup a planet tileserver. Tiles on lod 15 take up to 60 seconds with the faulty index and less less than 2 seconds with the correct index.