### PR TITLE
Use current environment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -80,7 +80,7 @@ if [ "$1" = "import" ]; then
 
     #Import external data
     sudo chown -R renderer: /home/renderer/src
-    sudo -u renderer python3 /home/renderer/src/openstreetmap-carto/scripts/get-external-data.py -c /home/renderer/src/openstreetmap-carto/external-data.yml -D /home/renderer/src/openstreetmap-carto/data
+    sudo -E -u renderer python3 /home/renderer/src/openstreetmap-carto/scripts/get-external-data.py -c /home/renderer/src/openstreetmap-carto/external-data.yml -D /home/renderer/src/openstreetmap-carto/data
 
     # Register that data has changed for mod_tile caching purposes
     touch /var/lib/mod_tile/planet-import-complete


### PR DESCRIPTION
The image could not import the data if the image was run on a server behind an http proxy. The proxy setup was correct, however, the environment variables (HTTP_PROXY and HTTPS_PROXY) were not used by the user `renderer` in the specified command which caused the import process to fail with error message `urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='osmdata.openstreetmap.de', port=443): Max retries exceeded with url: /download/simplified-water-polygons-split-3857.zip (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fb878a71fa0>: Failed to establish a new connection: [Errno 111] Connection refused'))`.
Changing the specified command, to copy the environment over to the user renderer fixes this problem.