### PR TITLE
Build, test and deploy with Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/.github/
+/.travis.yml
+/docker-compose.yml
+/LICENSE
+/Makefile
+/README.md

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,139 @@
+name: Build and test image
+
+on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - 'v*'
+  pull_request:
+    branches:
+    - master
+
+env:
+  IMAGE : ${{ github.repository_owner }}/openstreetmap-tile-server
+  TAG   : ${{ github.sha }}
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      VOLUME    : osm-db
+      CONTAINER : osm-www
+      MOUNT     : /var/lib/postgresql/14/main
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v3
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    -
+      name: Environment
+      run : |
+        echo  IMAGE=$(echo ${{ env.IMAGE }} | tr '[:upper:]' '[:lower:]')  >>$GITHUB_ENV
+    -
+      name: Docker build
+      uses: docker/build-push-action@v2
+      with:
+        pull       : true
+        load       : true
+        context    : .
+        file       : ./Dockerfile
+        tags       : ${{env.IMAGE}}:${{env.TAG}}
+        cache-from : type=gha,scope=${{ github.workflow }}
+        cache-to   : type=gha,scope=${{ github.workflow }},mode=max
+    -
+      name: Import Luxembourg
+      run : |
+        docker  volume  create  ${VOLUME}
+        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  ${IMAGE}:${TAG}  import
+    -
+      name: Start server
+      run : |
+        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -p 80:80  -d  --name ${CONTAINER}  ${IMAGE}:${TAG}  run
+        sleep 30
+    -
+      name: Download tiles
+      run : |
+        curl  http://localhost/tile/0/0/0.png            --fail  -o 000.png
+        curl  http://localhost/tile/1/0/0.png            --fail  -o 100.png
+        curl  http://localhost/tile/1/0/1.png            --fail  -o 101.png
+        curl  http://localhost/tile/1/1/0.png            --fail  -o 110.png
+        curl  http://localhost/tile/1/1/1.png            --fail  -o 111.png
+        curl  http://localhost/tile/18/138474/85459.png  --fail  -o empty.png
+        curl  http://localhost/tile/18/135536/89345.png  --fail  -o example.png
+    -
+      name: Verify tiles
+      run : |
+        sha1sum  *.png
+        sha1sum  --check  <<EOF
+        8aeddc612a8a4fbc480dbd3241739ccf19938f11 *000.png
+        194ae70330d54bc0ab95441e0c46774232e3c4a4 *100.png
+        7d78800b607ad769cf0280744f04dfd92e31ffd1 *101.png
+        62ae1081b8613b542fb650136ff15ffac9c7818d *110.png
+        3f72d900803266ce8e7fe27d25eb251f29cba3d0 *111.png
+        c226ca747874fb1307eef853feaf9d8db28cef2b *empty.png
+        EOF
+        ! diff  empty.png  example.png  ||  (  >&2  echo  "ERROR: example.png is empty"  &&  exit 1  )
+    -
+      name: Cleanup
+      run : |
+        docker  rm  --force  --volumes  ${CONTAINER}
+        docker  volume  rm  --force  ${VOLUME}
+        docker  rmi  --force  ${IMAGE}:${TAG}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+    - test
+    if: github.event_name != 'pull_request'
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v3
+    -
+      name: Environment
+      run : |
+        echo  IMAGE=$(echo ${{ env.IMAGE }} | tr '[:upper:]' '[:lower:]')  >>$GITHUB_ENV
+    -
+      name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ env.IMAGE }}
+        tags: |
+          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    -
+      name: Login to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry : ghcr.io
+        username : ${{ github.repository_owner }}
+        password : ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        pull       : true
+        push       : true
+        context    : .
+        file       : ./Dockerfile
+        tags       : ${{ steps.meta.outputs.tags }}
+        labels     : ${{ steps.meta.outputs.labels }}
+        cache-from : type=gha,scope=${{ github.workflow }}
+        cache-to   : type=gha,scope=${{ github.workflow }},mode=max

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -68,18 +68,31 @@ jobs:
         curl  http://localhost/tile/18/138474/85459.png  --fail  -o empty.png
         curl  http://localhost/tile/18/135536/89345.png  --fail  -o example.png
     -
+      name: Upload tiles
+      uses: actions/upload-artifact@v3
+      with:
+        name: tiles
+        path: '*.png'
+    -
       name: Verify tiles
       run : |
         sha1sum  *.png
         sha1sum  --check  <<EOF
-        8aeddc612a8a4fbc480dbd3241739ccf19938f11 *000.png
-        194ae70330d54bc0ab95441e0c46774232e3c4a4 *100.png
-        7d78800b607ad769cf0280744f04dfd92e31ffd1 *101.png
-        62ae1081b8613b542fb650136ff15ffac9c7818d *110.png
-        3f72d900803266ce8e7fe27d25eb251f29cba3d0 *111.png
         c226ca747874fb1307eef853feaf9d8db28cef2b *empty.png
         EOF
-        ! diff  empty.png  example.png  ||  (  >&2  echo  "ERROR: example.png is empty"  &&  exit 1  )
+        tiles=(`ls *.png`)
+        for ((i=0; i<${#tiles[@]}; i++)) ; do
+          if [ `file  --brief  --mime-type  "${tiles[$i]}"` != 'image/png' ] ; then
+            >&2  echo  "ERROR: ${tiles[$i]} is not a image/png file"
+            exit 1
+          fi
+          for ((j=i+1; j<${#tiles[@]}; j++)) ; do
+            if ( diff  "${tiles[$i]}"  "${tiles[$j]}" ) ; then
+              >&2  echo  "ERROR: ${tiles[$i]} is identical to ${tiles[$j]}"
+              exit 2
+            fi
+          done
+        done
     -
       name: Cleanup
       run : |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -113,12 +113,14 @@ jobs:
       name: Environment
       run : |
         echo  IMAGE=$(echo ${{ env.IMAGE }} | tr '[:upper:]' '[:lower:]')  >>$GITHUB_ENV
+        echo  DOCKERHUB_IMAGE=$([ "${{ secrets.DOCKERHUB_USERNAME }}" != '' ] && [ "${{ secrets.DOCKERHUB_PASSWORD }}" != "" ] && echo "$IMAGE")  >>$GITHUB_ENV
     -
       name: Docker meta
       id: meta
       uses: docker/metadata-action@v3
       with:
         images: |
+          ${{ env.DOCKERHUB_IMAGE }}
           ghcr.io/${{ env.IMAGE }}
         tags: |
           type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
@@ -131,6 +133,13 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    -
+      name: Login to DockerHub
+      uses: docker/login-action@v1
+      if: ${{ env.DOCKERHUB_IMAGE != '' }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
     -
       name: Login to GHCR
       uses: docker/login-action@v1

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,7 +3,7 @@ name: Build and test image
 on:
   push:
     branches:
-    - 'master'
+    - master
     tags:
     - 'v*'
   pull_request:
@@ -51,11 +51,11 @@ jobs:
       name: Import Luxembourg
       run : |
         docker  volume  create  ${VOLUME}
-        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  ${IMAGE}:${TAG}  import
+        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -e UPDATES=enabled  ${IMAGE}:${TAG}  import
     -
       name: Start server
       run : |
-        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -p 80:80  -d  --name ${CONTAINER}  ${IMAGE}:${TAG}  run
+        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -e UPDATES=enabled  -p 80:80  -d  --name ${CONTAINER}  ${IMAGE}:${TAG}  run
         sleep 30
     -
       name: Download tiles
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - test
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
     -
       name: Checkout

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Alexander Overvoorde
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
This PR is a proposal for issue #254

It adds a Github Actions workflow on pull requests and pushes to `master` and version tags to automatically build, test and deploy the docker image.

## Test

The following things are tested:
- build docker image
- Import the default region (Luxembourg) with automatic updates
- Start the server with automatic updates
- Download all zoom 0 and zoom 1 tiles
- Download a zoom 18 tile outside of the default region (empty tile).
- Download a zoom 18 tile inside of the default region.
- Verify the empty tile against a known checksum.
- Verify that all tiles are `image/png` files.
- Verify that all tiles are different from another.

The empty tile shouldn't change very often, even when the style updates. But in the future the hard-coded checksum might need to be adjusted.

## Runtime

The first build takes about 15 to 20 minutes. (Or when the base `ubuntu` image is updated.)

After that the build cache is stored into the [Github Actions cache](https://github.com/actions/cache) to speed up following builds to about 5 to 8 minutes.

## Deployment

Pushing `master` or tags that start with `v` are pushed to the [Github Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).

You can see an [example](https://github.com/Istador/openstreetmap-tile-server/pkgs/container/openstreetmap-tile-server) of that in my fork. The `Github Container Registry` is private by default. To make it public the project owner needs to change the visibility settings once.

A push of the tag `v1.9.2` for example would push the following docker tags: `latest`, `1.9.2`, `1.9`, and `1`.
Pushes to `master` only push the `latest` tag.

It can easily be extended to login and push to Docker Hub too (to replace the `.travis.yml`). Simply add `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` as repository secrets.

## Other
I tried to build for other architectures than `linux/amd64` but all the builds failed for me.

This PR should not trigger an action, because PRs are using the workflow defined in the branch they want to merge to (`master`) and not what their changes might introduce.

I added the `LICENSE` file, because the license used by this repository is automatically read by the action and added as a label to the build docker image (additional to some other useful labels, e.g. the version and the commit hash). Without the file it set the label `org.opencontainers.image.licenses` to `""`. Also with it Github will correctly displays the license used by the project.

---

After this is merged, if someone creates a new fork of this repository, the actions should work with the fork automatically. Building them their own docker image that they can use directly (after some build time) without additional setup.

Therefore you should be able to test this pull request by simply forking my fork.