### PR TITLE
cancel outdated jobs for the same reference

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,6 +10,11 @@ on:
     branches:
     - master
 
+# cancel outdated jobs for the same reference
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE : ${{ github.repository_owner }}/openstreetmap-tile-server
   TAG   : ${{ github.sha }}


### PR DESCRIPTION
Otherwise the order of the deployment is not guaranteed.

E.g. when merging and pushing two things shortly after another, the older version might deploy last.

This is a follow up for #260