### PR TITLE
leaflet-demo: Add Location link

### DIFF
--- a/LICENSE.leaflet.Permalink
+++ b/LICENSE.leaflet.Permalink
@@ -1,0 +1,23 @@
+License for The leaflet.Permalink component:
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Marc Chasse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -277,3 +277,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+The address-bar permalink in `leaflet-demo.html` is based on
+[leaflet.Permalink](https://github.com/MarcChasse/leaflet.Permalink)
+by Marc Chasse, which is licensed under the MIT License.

--- a/leaflet-demo.html
+++ b/leaflet-demo.html
@@ -23,13 +23,72 @@
         <div id="map"></div>
 
         <script>
-            var map = L.map('map').setView([0, 0], 3);
+            // permalink support: https://github.com/MarcChasse/leaflet.Permalink
+            L.Permalink = {
+                //gets the map center, zoom-level and rotation from the URL if present, else uses default values
+                getMapLocation: function (zoom, center) {
+                    'use strict';
+                    zoom = (zoom || zoom === 0) ? zoom : 18;
+                    center = (center) ? center : [52.26869, -113.81034];
 
+                    if (window.location.hash !== '') {
+                        var hash = window.location.hash.replace('#', '');
+                        var parts = hash.split(',');
+                        if (parts.length === 3) {
+                            center = {
+                                lat: parseFloat(parts[0]),
+                                lng: parseFloat(parts[1])
+                            };
+                            zoom = parseInt(parts[2].slice(0, -1), 10);
+                        }
+                    }
+                    return {zoom: zoom, center: center};
+                },
+
+                setup: function (map) {
+                    'use strict';
+                    var shouldUpdate = true;
+                    var updatePermalink = function () {
+                        if (!shouldUpdate) {
+                            // do not update the URL when the view was changed in the 'popstate' handler (browser history navigation)
+                            shouldUpdate = true;
+                            return;
+                        }
+
+                        var center = map.getCenter();
+                        var hash = '#' +
+                                Math.round(center.lat * 100000) / 100000 + ',' +
+                                Math.round(center.lng * 100000) / 100000 + ',' +
+                                map.getZoom() + 'z';
+                        var state = {
+                            zoom: map.getZoom(),
+                            center: center
+                        };
+                        window.history.pushState(state, 'map', hash);
+                    };
+
+                    map.on('moveend', updatePermalink);
+
+                    // restore the view state when navigating through the history, see
+                    // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate
+                    window.addEventListener('popstate', function (event) {
+                        if (event.state === null) {
+                            return;
+                        }
+                        map.setView(event.state.center, event.state.zoom);
+                        shouldUpdate = false;
+                    });
+                }
+            };
+
+            var mapPos = L.Permalink.getMapLocation(3, [0, 0]);
+            var map = L.map('map', { center: mapPos.center, zoom: mapPos.zoom });
             L.tileLayer('/tile/{z}/{x}/{y}.png', {
                 maxZoom: 18,
                 attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
                 id: 'base'
             }).addTo(map);
+            L.Permalink.setup(map);
         </script>
     </body>
 </html>

--- a/leaflet-demo.html
+++ b/leaflet-demo.html
@@ -23,7 +23,7 @@
         <div id="map"></div>
 
         <script>
-            // permalink support: https://github.com/MarcChasse/leaflet.Permalink
+            // permalink support: based on https://github.com/MarcChasse/leaflet.Permalink
             L.Permalink = {
                 //gets the map center, zoom-level and rotation from the URL if present, else uses default values
                 getMapLocation: function (zoom, center) {
@@ -31,15 +31,14 @@
                     zoom = (zoom || zoom === 0) ? zoom : 18;
                     center = (center) ? center : [52.26869, -113.81034];
 
-                    if (window.location.hash !== '') {
-                        var hash = window.location.hash.replace('#', '');
-                        var parts = hash.split(',');
-                        if (parts.length === 3) {
+                    if (window.location.hash.startsWith('#map=')) {
+                        var parts = window.location.hash.substring(5).split('/');
+                        if (parts.length >= 3) {
+                            zoom = parseInt(parts[0]);
                             center = {
-                                lat: parseFloat(parts[0]),
-                                lng: parseFloat(parts[1])
+                                lat: parseFloat(parts[1]),
+                                lng: parseFloat(parts[2])
                             };
-                            zoom = parseInt(parts[2].slice(0, -1), 10);
                         }
                     }
                     return {zoom: zoom, center: center};
@@ -56,10 +55,10 @@
                         }
 
                         var center = map.getCenter();
-                        var hash = '#' +
-                                Math.round(center.lat * 100000) / 100000 + ',' +
-                                Math.round(center.lng * 100000) / 100000 + ',' +
-                                map.getZoom() + 'z';
+                        var hash = '#map=' +
+                                map.getZoom() + '/' +
+                                Math.round(center.lat * 100000) / 100000 + '/' +
+                                Math.round(center.lng * 100000) / 100000
                         var state = {
                             zoom: map.getZoom(),
                             center: center


### PR DESCRIPTION
For ease of use, this adds a location link to leaflet-demo's url hash with the same format as OSM's, updated whenever the map is scrolled or zoomed.

OSM link: https://www.openstreetmap.org/#map=16/43.0490/-76.1496
Localhost link: http://localhost:8080/#map=16/43.0490/-76.1496

openstreetmap-tile-server is great to use, and this feature would save me a bunch of time when I'm testing with it on my laptop.

This is based on https://github.com/MarcChasse/leaflet.Permalink (MIT-licensed) because it's short and simple. Updated it to use the same link format as OSM.

This would also take care of #278.

Thanks!