### PR TITLE
warn about FLAT_NODES w/ UPDATES incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ docker run \
     import
 ```
 
+Warning: enabling `FLAT_NOTES` together with `UPDATES` only works for entire planet imports (without a `.poly` file).  Otherwise this will break the automatic update script. This is because trimming the differential updates to the specific regions currently isn't supported when using flat nodes.
+
 ### Benchmarks
 
 You can find an example of the import performance to expect with this image on the [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Osm2pgsql/benchmarks#debian_9_.2F_openstreetmap-tile-server).


### PR DESCRIPTION
`FLAT_NODES` and `UPDATES` are incompatible when using a `.poly` file.

The database table `planet_osm_nodes` is required by the `trim_osc.py` script, but it isn't created when using flat nodes. See https://github.com/Zverik/regional/issues/17.

The `trim_osc.py` script is only called when `/data/database/region.poly` exists, so it should not affect full planet imports without `.poly` files.

https://github.com/Overv/openstreetmap-tile-server/blob/5572c9722ef7cc478d0143436b9f723c54171527/openstreetmap-tiles-update-expire.sh#L17

https://github.com/Overv/openstreetmap-tile-server/blob/5572c9722ef7cc478d0143436b9f723c54171527/openstreetmap-tiles-update-expire.sh#L33-L35

https://github.com/Overv/openstreetmap-tile-server/blob/5572c9722ef7cc478d0143436b9f723c54171527/openstreetmap-tiles-update-expire.sh#L154-L161