### PR TITLE
multiarch build for additional linux/arm64/v8 support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -159,7 +159,7 @@ jobs:
       with:
         pull       : true
         push       : true
-        platforms  : linux/amd64,linux/arm64/v8,linux/arm/v7
+        platforms  : linux/amd64,linux/arm64/v8
         context    : .
         file       : ./Dockerfile
         tags       : ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,8 +60,9 @@ jobs:
     -
       name: Start server
       run : |
-        docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -e UPDATES=enabled  -p 80:80  -d  --name ${CONTAINER}  ${IMAGE}:${TAG}  run
+        docker  run  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -e UPDATES=enabled  -p 80:80  -d  --name ${CONTAINER}  ${IMAGE}:${TAG}  run
         sleep 30
+        docker  logs  ${CONTAINER}
     -
       name: Download tiles
       run : |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,50 +21,65 @@ env:
 
 jobs:
 
-  test:
+  build:
+    strategy:
+      matrix:
+        include:
+        - arch    : amd64
+          mode    : build-and-test
+        - arch    : arm64
+          variant : v8
+          mode    : build-only
     runs-on: ubuntu-latest
     env:
       VOLUME    : osm-db
       CONTAINER : osm-www
       MOUNT     : /data/database/
+      PLATFORM  : linux/${{ matrix.arch }}${{ (matrix.variant != '' && format('/{0}', matrix.variant)) || '' }}
     steps:
     -
       name: Checkout
       uses: actions/checkout@v3
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: ${{ matrix.arch }}
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     -
       name: Environment
       run : |
         echo  IMAGE=$(echo ${{ env.IMAGE }} | tr '[:upper:]' '[:lower:]')  >>$GITHUB_ENV
     -
       name: Docker build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         pull       : true
-        load       : true
+        load       : ${{ matrix.mode == 'build-and-test' }}
+        platforms  : ${{ env.PLATFORM }}
         context    : .
         file       : ./Dockerfile
-        tags       : ${{env.IMAGE}}:${{env.TAG}}
-        cache-from : type=gha,scope=${{ github.workflow }}
-        cache-to   : type=gha,scope=${{ github.workflow }},mode=max
+        tags       : ${{ env.IMAGE }}:${{ env.TAG }}
+        cache-from : type=gha,scope=${{ github.workflow }}:${{ env.PLATFORM }}
+        cache-to   : type=gha,scope=${{ github.workflow }}:${{ env.PLATFORM }},mode=max
     -
       name: Import Luxembourg
+      if  : ${{ matrix.mode == 'build-and-test' }}
       run : |
         docker  volume  create  ${VOLUME}
         docker  run  --rm  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -e UPDATES=enabled  ${IMAGE}:${TAG}  import
     -
       name: Start server
+      if  : ${{ matrix.mode == 'build-and-test' }}
       run : |
         docker  run  --shm-size=128M  -v ${VOLUME}:${MOUNT}  -e UPDATES=enabled  -p 80:80  -d  --name ${CONTAINER}  ${IMAGE}:${TAG}  run
         sleep 30
         docker  logs  ${CONTAINER}
     -
       name: Download tiles
+      if  : ${{ matrix.mode == 'build-and-test' }}
       run : |
         curl  http://localhost/tile/0/0/0.png            --fail  -o 000.png
         curl  http://localhost/tile/1/0/0.png            --fail  -o 100.png
@@ -75,12 +90,14 @@ jobs:
         curl  http://localhost/tile/18/135536/89345.png  --fail  -o example.png
     -
       name: Upload tiles
+      if  : ${{ matrix.mode == 'build-and-test' }}
       uses: actions/upload-artifact@v3
       with:
         name: tiles
         path: '*.png'
     -
       name: Verify tiles
+      if  : ${{ matrix.mode == 'build-and-test' }}
       run : |
         sha1sum  *.png
         sha1sum  --check  <<EOF
@@ -101,6 +118,7 @@ jobs:
         done
     -
       name: Cleanup
+      if  : ${{ matrix.mode == 'build-and-test' }}
       run : |
         docker  rm  --force  --volumes  ${CONTAINER}
         docker  volume  rm  --force  ${VOLUME}
@@ -109,7 +127,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs:
-    - test
+    - build
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     -
@@ -123,7 +141,7 @@ jobs:
     -
       name: Docker meta
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: |
           ${{ env.DOCKERHUB_IMAGE }}
@@ -135,27 +153,29 @@ jobs:
           type=semver,pattern={{major}}
     -
       name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: amd64,arm64
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     -
       name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       if: ${{ env.DOCKERHUB_IMAGE != '' }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     -
       name: Login to GHCR
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry : ghcr.io
         username : ${{ github.repository_owner }}
         password : ${{ secrets.GITHUB_TOKEN }}
     -
       name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         pull       : true
         push       : true
@@ -164,5 +184,6 @@ jobs:
         file       : ./Dockerfile
         tags       : ${{ steps.meta.outputs.tags }}
         labels     : ${{ steps.meta.outputs.labels }}
-        cache-from : type=gha,scope=${{ github.workflow }}
-        cache-to   : type=gha,scope=${{ github.workflow }},mode=max
+        cache-from: |
+          type=gha,scope=${{ github.workflow }}:linux/amd64
+          type=gha,scope=${{ github.workflow }}:linux/arm64/v8

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -158,6 +158,7 @@ jobs:
       with:
         pull       : true
         push       : true
+        platforms  : linux/amd64,linux/arm64/v8,linux/arm/v7
         context    : .
         file       : ./Dockerfile
         tags       : ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request fixes issue #291.

Additional architectures that are available with `ubuntu:22.04` but that didn't build successfully:

<details><summary><a href="https://github.com/Istador/openstreetmap-tile-server/actions/runs/2637308244">riscv64</a></summary>
<pre><code>#77 [linux/riscv64 final  3/19] RUN apt-get update && apt-get install -y --no-install-recommends  apache2  cron  dateutils  fonts-noto-cjk  fonts-noto-hinted  fonts-noto-unhinted  fonts-unifont  gnupg2  gdal-bin  liblua5.3-dev  lua5.3  mapnik-utils  npm  osm2pgsql  osmium-tool  osmosis  postgresql-14  postgresql-14-postgis-3  postgresql-14-postgis-3-scripts  postgis  python-is-python3  python3-mapnik  python3-lxml  python3-psycopg2  python3-shapely  python3-pip  renderd  sudo  wget && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
#77 0.790 Get:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
#77 1.577 Get:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [114 kB]
#77 1.764 Get:3 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [99.8 kB]
#77 1.945 Get:4 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease [110 kB]
#77 3.535 Get:5 http://ports.ubuntu.com/ubuntu-ports jammy/main riscv64 Packages [1653 kB]
#77 4.235 Get:6 http://ports.ubuntu.com/ubuntu-ports jammy/restricted riscv64 Packages [5829 B]
#77 4.238 Get:7 http://ports.ubuntu.com/ubuntu-ports jammy/universe riscv64 Packages [16.6 MB]
#77 6.312 Get:8 http://ports.ubuntu.com/ubuntu-ports jammy/multiverse riscv64 Packages [192 kB]
#77 7.266 Get:9 http://ports.ubuntu.com/ubuntu-ports jammy-updates/restricted riscv64 Packages [3689 B]
#77 7.422 Get:10 http://ports.ubuntu.com/ubuntu-ports jammy-updates/universe riscv64 Packages [119 kB]
#77 7.442 Get:11 http://ports.ubuntu.com/ubuntu-ports jammy-updates/multiverse riscv64 Packages [676 B]
#77 7.459 Get:12 http://ports.ubuntu.com/ubuntu-ports jammy-updates/main riscv64 Packages [253 kB]
#77 10.70 Get:13 http://ports.ubuntu.com/ubuntu-ports jammy-backports/universe riscv64 Packages [5809 B]
#77 14.08 Get:14 http://ports.ubuntu.com/ubuntu-ports jammy-security/main riscv64 Packages [112 kB]
#77 14.24 Get:15 http://ports.ubuntu.com/ubuntu-ports jammy-security/restricted riscv64 Packages [3318 B]
#77 14.24 Get:16 http://ports.ubuntu.com/ubuntu-ports jammy-security/universe riscv64 Packages [52.5 kB]
#77 14.61 Fetched 19.6 MB in 14s (1379 kB/s)
#77 14.61 Reading package lists...
#77 14.61 Reading package lists...
#77 21.25 Reading package lists...
#77 27.44 Building dependency tree...
#77 27.99 Reading state information...
#77 28.40 Some packages could not be installed. This may mean that you have
#77 28.40 requested an impossible situation or if you are using the unstable
#77 28.40 distribution that some required packages have not yet been created
#77 28.40 or been moved out of Incoming.
#77 28.40 The following information may help to resolve the situation:
#77 28.40 
#77 28.40 The following packages have unmet dependencies:
#77 28.75  npm : Depends: node-agent-base but it is not going to be installed
#77 28.75        Depends: node-aproba but it is not going to be installed
#77 28.75        Depends: node-archy but it is not going to be installed
#77 28.75        Depends: node-cacache but it is not going to be installed
#77 28.75        Depends: node-chalk but it is not going to be installed
#77 28.75        Depends: node-cli-table3
#77 28.75        Depends: node-colors but it is not going to be installed
#77 28.75        Depends: node-columnify but it is not going to be installed
#77 28.75        Depends: node-debug but it is not going to be installed
#77 28.75        Depends: node-emoji-regex
#77 28.75        Depends: node-got but it is not going to be installed
#77 28.75        Depends: node-graceful-fs but it is not going to be installed
#77 28.75        Depends: node-gyp but it is not going to be installed
#77 28.75        Depends: node-https-proxy-agent but it is not going to be installed
#77 28.75        Depends: node-mkdirp but it is not going to be installed
#77 28.75        Depends: node-ms but it is not going to be installed
#77 28.75        Depends: node-nopt but it is not going to be installed
#77 28.75        Depends: node-normalize-package-data but it is not going to be installed
#77 28.75        Depends: node-npm-package-arg but it is not going to be installed
#77 28.75        Depends: node-npmlog but it is not going to be installed
#77 28.75        Depends: node-read-package-json but it is not going to be installed
#77 28.75        Depends: node-rimraf but it is not going to be installed
#77 28.75        Depends: node-semver but it is not going to be installed
#77 28.75        Depends: node-ssri but it is not going to be installed
#77 28.75        Depends: node-string-width but it is not going to be installed
#77 28.76        Depends: node-strip-ansi but it is not going to be installed
#77 28.76        Depends: node-tar but it is not going to be installed
#77 28.76        Depends: node-validate-npm-package-name but it is not going to be installed
#77 28.76        Depends: node-which but it is not going to be installed
#77 28.76        Depends: node-write-file-atomic but it is not going to be installed
#77 28.76        Depends: nodejs:any (>= 10) but it is not installable
#77 28.77 E: Unable to correct problems, you have held broken packages.
</code></pre>
</details>

<details><summary><a href="https://github.com/Istador/openstreetmap-tile-server/runs/7254969761">ppc64le</a></summary>
<pre><code>#79 [linux/ppc64le final  3/19] RUN apt-get update && apt-get install -y --no-install-recommends  apache2  cron  dateutils  fonts-noto-cjk  fonts-noto-hinted  fonts-noto-unhinted  fonts-unifont  gnupg2  gdal-bin  liblua5.3-dev  lua5.3  mapnik-utils  npm  osm2pgsql  osmium-tool  osmosis  postgresql-14  postgresql-14-postgis-3  postgresql-14-postgis-3-scripts  postgis  python-is-python3  python3-mapnik  python3-lxml  python3-psycopg2  python3-shapely  python3-pip  renderd  sudo  wget && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
[...]
#79 673.1 Setting up openjdk-11-jre-headless:ppc64el (11.0.15+10-0ubuntu0.22.04.1) ...
#79 673.5 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/java to provide /usr/bin/java (java) in auto mode
#79 673.6 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/jjs to provide /usr/bin/jjs (jjs) in auto mode
#79 673.6 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/keytool to provide /usr/bin/keytool (keytool) in auto mode
#79 673.7 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/rmid to provide /usr/bin/rmid (rmid) in auto mode
#79 673.8 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/rmiregistry to provide /usr/bin/rmiregistry (rmiregistry) in auto mode
#79 673.9 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/pack200 to provide /usr/bin/pack200 (pack200) in auto mode
#79 674.0 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/bin/unpack200 to provide /usr/bin/unpack200 (unpack200) in auto mode
#79 674.1 update-alternatives: using /usr/lib/jvm/java-11-openjdk-ppc64el/lib/jexec to provide /usr/bin/jexec (jexec) in auto mode
#79 674.1 Setting up osmosis (0.48.3-1) ...
#79 674.1 Setting up ca-certificates-java (20190909) ...
#79 674.6 head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
#79 675.4 Unknown privilege violation (03)
#79 675.4 NIP 000000401378b3b0   LR 00000040032af5f8 CTR 000000401378b380 XER 0000000000000000 CPU#1
#79 675.4 MSR 9000000102806901 HID0 0000000000000000  HF 02806105 iidx 0 didx 0
#79 675.4 TB 00000415 1782418786549
#79 675.4 GPR00 ffffffbffc2c27e0 0000004003d3d7c0 0000004003607f00 0000004003d3e820
#79 675.4 GPR04 0000000000000000 0000000000002000 0000000000000000 0000000000000000
#79 675.4 GPR08 0000004003667f00 000000400362ae24 0000000000000001 0000000000000000
#79 675.4 GPR12 000000401378b380 0000004003d488e0 0000004000021360 0000004000021360
#79 675.4 GPR16 0000004003d41160 0000004003b42000 000000401378b3a4 000000401378b3ac
#79 675.4 GPR20 000000401378b3d0 000000400362ae30 000000401378b380 000000401378b3d8
#79 675.4 GPR24 0000004003638c28 00000000000003d8 0000004004016b88 00000040040167a0
#79 675.4 GPR28 0000004003d3f820 0000004004015870 00000040036699c0 0000004003d3d7c0
#79 675.4 CR 28884400  [ E  L  L  L  G  G  -  -  ]             RES 0000004003d3e820
#79 676.6 qemu: fatal: Tried to call a TRAP
#79 676.6 
#79 676.6 NIP 00000040137cf30c   LR 0000004013d20644 CTR 0000004013d20500 XER 0000000020040000 CPU#1
#79 676.6 MSR 9000000102806901 HID0 0000000000000000  HF 02806105 iidx 0 didx 0
#79 676.6 TB 00000415 1785164745317
#79 676.6 GPR00 0000000000000040 0000004003d3f6e0 0000004013d20480 00000000fff4c848
#79 676.6 GPR04 000000404dc742d8 000000000000019e 0000004003d3f848 0000000000000000
#79 676.6 GPR08 000000404db00080 000000404db000f8 0000000000000003 0000000100007ab8
#79 676.6 GPR12 0000000100001808 0000004003d488e0 000000404db000ba 0000004003d3f7b0
#79 676.6 GPR16 0000004004015000 00000000fff4c848 0000004003d3f860 00000040041f0220
#79 676.6 GPR20 0000004013792f90 0000004003d3f730 0000000000000007 0000000044000009
#79 676.6 GPR24 00000040137ae000 000000400364be30 0000004003d3f7c8 000000404db05190
#79 676.6 GPR28 000000404dc77378 000000401378b000 0000000000000010 000000404daffd00
#79 676.6 CR 28884424  [ E  L  L  L  G  G  E  G  ]             RES ffffffffffffffff
#79 676.6 FPR00 0000000000000010 3ff000d729ceab09 3fc999999999999a 43d9d99960000000
#79 676.6 FPR04 6766656463626160 7776757473727170 8786858483828180 0000000000000000
#79 676.6 FPR08 0000000000000000 0000000000000000 0000000000000064 0000000000000064
#79 676.6 FPR12 0000000000000000 3736353433323130 0000000000000000 3fe8000000000000
#79 676.6 FPR16 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 676.6 FPR20 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 676.6 FPR24 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 676.6 FPR28 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 676.6 FPSCR 0000000092008000
#79 676.9 /var/lib/dpkg/info/ca-certificates-java.postinst: line 88: 21478 Done                    echo -e "-diginotar_root_ca\n-diginotar_root_ca_pem"
#79 676.9      21480 Aborted                 (core dumped) | java -Xmx64m -jar $JAR -storepass "$storepass"
#79 676.9 dpkg: error processing package ca-certificates-java (--configure):
#79 676.9  installed ca-certificates-java package post-installation script subprocess returned error exit status 134
#79 676.9 Processing triggers for libc-bin (2.35-0ubuntu3) ...
#79 677.1 Processing triggers for ca-certificates (20211016) ...
#79 677.3 Updating certificates in /etc/ssl/certs...
#79 697.3 0 added, 0 removed; done.
#79 697.3 Running hooks in /etc/ca-certificates/update.d...
#79 697.5 
#79 698.6 Unknown privilege violation (03)
#79 698.6 NIP 00000040137943b0   LR 00000040032af5f8 CTR 0000004013794380 XER 0000000000000000 CPU#1
#79 698.6 MSR 9000000102806901 HID0 0000000000000000  HF 02806105 iidx 0 didx 0
#79 698.6 TB 00000427 1837901459260
#79 698.6 GPR00 ffffffbffc2bc7e0 0000004003d437c0 0000004003607f00 0000004003d44820
#79 698.6 GPR04 0000000000000000 0000000000002000 0000000000000000 0000000000000000
#79 698.6 GPR08 0000004003667f00 000000400362ae24 0000000000000001 0000000000000000
#79 698.6 GPR12 0000004013794380 0000004003d4e8e0 0000004000021360 0000004000021360
#79 698.6 GPR16 0000004003d47160 0000004003b48000 00000040137943a4 00000040137943ac
#79 698.6 GPR20 00000040137943d0 000000400362ae30 0000004013794380 00000040137943d8
#79 698.6 GPR24 0000004003638c28 00000000000003d8 0000004004016b88 00000040040167a0
#79 698.6 GPR28 0000004003d45820 0000004004015870 00000040036699c0 0000004003d437c0
#79 698.6 CR 28884400  [ E  L  L  L  G  G  -  -  ]             RES 0000004003d44820
#79 699.7 qemu: fatal: Tried to call a TRAP
#79 699.7 
#79 699.7 NIP 0000004013d25e88   LR 0000004013d26b44 CTR 0000004013d26a00 XER 0000000020040000 CPU#1
#79 699.7 MSR 9000000102806901 HID0 0000000000000000  HF 02806105 iidx 0 didx 0
#79 699.7 TB 00000428 1840509242110
#79 699.7 GPR00 0000000000000040 0000004003d45640 0000004013d26980 00000000fff88fc8
#79 699.7 GPR04 000000404dc7d2d8 00000000000000ba 0000004003d457a8 0000000000000000
#79 699.7 GPR08 000000404db09080 000000404db05140 0000000000000000 0000004003d356b0
#79 699.7 GPR12 0000000100007ab8 0000004003d4e8e0 000000404db090ba 0000004003d45710
#79 699.7 GPR16 0000004004015000 00000000fff88fc8 0000004003d457c0 0000000100001808
#79 699.7 GPR20 000000401379bf90 0000004003d45690 ffffffff80000003 0000000000000070
#79 699.7 GPR24 00000040137b7000 000000400364be30 0000004003d45728 000000404db0e190
#79 699.7 GPR28 000000404dc80800 0000004013794000 0000000000000010 000000404db090f8
#79 699.7 CR 42884484  [ G  E  L  L  G  G  L  G  ]             RES ffffffffffffffff
#79 699.7 FPR00 0000000000000000 3ff000853ce957eb 3fc999999999999a 43d9d99960000000
#79 699.7 FPR04 6766656463626160 7776757473727170 8786858483828180 0000000000000000
#79 699.7 FPR08 0000000000000000 0000000000000000 00000000000000c8 00000000000007d0
#79 699.7 FPR12 0000000000000000 3736353433323130 0000000000000000 3fe8000000000000
#79 699.7 FPR16 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 699.7 FPR20 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 699.7 FPR24 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 699.7 FPR28 0000000000000000 0000000000000000 0000000000000000 0000000000000000
#79 699.7 FPSCR 0000000092008000
#79 700.0 Aborted (core dumped)
#79 700.0 E: /etc/ca-certificates/update.d/jks-keystore exited with code 1.
#79 700.0 done.
#79 700.1 Errors were encountered while processing:
#79 700.1  ca-certificates-java
#79 700.3 E: Sub-process /usr/bin/dpkg returned an error code (1)
</code></pre>
</details>

<details><summary><a href="https://github.com/Istador/openstreetmap-tile-server/actions/runs/7255227471">s390x</a></summary>
<pre><code>#77 [linux/s390x final  3/19] RUN apt-get update && apt-get install -y --no-install-recommends  apache2  cron  dateutils  fonts-noto-cjk  fonts-noto-hinted  fonts-noto-unhinted  fonts-unifont  gnupg2  gdal-bin  liblua5.3-dev  lua5.3  mapnik-utils  npm  osm2pgsql  osmium-tool  osmosis  postgresql-14  postgresql-14-postgis-3  postgresql-14-postgis-3-scripts  postgis  python-is-python3  python3-mapnik  python3-lxml  python3-psycopg2  python3-shapely  python3-pip  renderd  sudo  wget && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
#77 0.892 Get:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
#77 1.674 Get:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [114 kB]
#77 1.857 Get:3 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [99.8 kB]
#77 2.043 Get:4 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease [110 kB]
#77 3.925 Get:5 http://ports.ubuntu.com/ubuntu-ports jammy/multiverse s390x Packages [191 kB]
#77 4.316 Get:6 http://ports.ubuntu.com/ubuntu-ports jammy/main s390x Packages [1691 kB]
#77 4.768 Get:7 http://ports.ubuntu.com/ubuntu-ports jammy/restricted s390x Packages [5829 B]
#77 4.785 Get:8 http://ports.ubuntu.com/ubuntu-ports jammy/universe s390x Packages [16.6 MB]
#77 9.003 Get:9 http://ports.ubuntu.com/ubuntu-ports jammy-updates/restricted s390x Packages [3689 B]
#77 9.163 Get:10 http://ports.ubuntu.com/ubuntu-ports jammy-updates/main s390x Packages [295 kB]
#77 9.222 Get:11 http://ports.ubuntu.com/ubuntu-ports jammy-updates/universe s390x Packages [130 kB]
#77 9.252 Get:12 http://ports.ubuntu.com/ubuntu-ports jammy-updates/multiverse s390x Packages [676 B]
#77 12.88 Get:13 http://ports.ubuntu.com/ubuntu-ports jammy-backports/universe s390x Packages [5799 B]
#77 17.10 Get:14 http://ports.ubuntu.com/ubuntu-ports jammy-security/main s390x Packages [139 kB]
#77 17.27 Get:15 http://ports.ubuntu.com/ubuntu-ports jammy-security/restricted s390x Packages [3318 B]
#77 17.27 Get:16 http://ports.ubuntu.com/ubuntu-ports jammy-security/universe s390x Packages [54.0 kB]
#77 20.71 Fetched 19.7 MB in 20s (975 kB/s)
#77 20.71 Reading package lists...
#77 20.71 Reading package lists...
#77 30.11 Reading package lists...
#77 30.11 Reading package lists...
#77 38.60 Building dependency tree...
#77 39.58 Reading state information...
#77 39.60 Package osmium-tool is not available, but is referred to by another package.
#77 39.60 This may mean that the package is missing, has been obsoleted, or
#77 39.60 is only available from another source
#77 39.60 
#77 39.61 E: Package 'osmium-tool' has no installation candidate
</code></pre>
</details>