### PR TITLE
Actually allow modifying the replication URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ FROM ubuntu:22.04 AS final
 ENV DEBIAN_FRONTEND=noninteractive
 ENV AUTOVACUUM=on
 ENV UPDATES=disabled
+ENV REPLICATION_URL=https://planet.openstreetmap.org/replication/hour/
+ENV MAX_INTERVAL_SECONDS=3600
+
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Get packages

--- a/openstreetmap-tiles-update-expire.sh
+++ b/openstreetmap-tiles-update-expire.sh
@@ -61,10 +61,6 @@ EXPIRY_TOUCHFROM=13
 EXPIRY_DELETEFROM=19
 EXPIRY_MAXZOOM=20
 
-
-REPLICATION_URL=${REPLICATION_URL:="https://planet.openstreetmap.org/replication/hour/"}
-MAX_INTERVAL_SECONDS=${MAX_INTERVAL_SECONDS:="3600"}
-
 #*************************************************************************
 #*************************************************************************
 

--- a/run.sh
+++ b/run.sh
@@ -81,7 +81,7 @@ if [ "$1" == "import" ]; then
         REPLICATION_TIMESTAMP=`osmium fileinfo -g header.option.osmosis_replication_timestamp /data/region.osm.pbf`
 
         # initial setup of osmosis workspace (for consecutive updates)
-        sudo -u renderer openstreetmap-tiles-update-expire.sh $REPLICATION_TIMESTAMP
+        sudo -E -u renderer openstreetmap-tiles-update-expire.sh $REPLICATION_TIMESTAMP
     fi
 
     # copy polygon file if available


### PR DESCRIPTION
So I goofed in https://github.com/Overv/openstreetmap-tile-server/pull/234 and didn't actually pass the URL to the script that needed it, so despite the documentation suggesting you could modify the URL, you couldn't.