### PR TITLE
validate version tags

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
     tags:
-    - 'v*'
+    - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
     - master


### PR DESCRIPTION
so non-semver tags don't trigger a deployment that will fail.

It's not a normal regexp syntax. Dots `.` will only match dots and not any characters.