### PR TITLE
upgrade leaflet from v1.7.1 to v1.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,9 +102,15 @@ RUN echo "LoadModule tile_module /usr/lib/apache2/modules/mod_tile.so" >> /etc/a
 && echo "LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so" >> /etc/apache2/conf-available/mod_headers.conf \
 && a2enconf mod_tile && a2enconf mod_headers
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
-COPY leaflet-demo.html /var/www/html/index.html
 RUN ln -sf /dev/stdout /var/log/apache2/access.log \
 && ln -sf /dev/stderr /var/log/apache2/error.log
+
+# leaflet
+COPY leaflet-demo.html /var/www/html/index.html
+RUN cd /var/www/html/ \
+&& wget https://github.com/Leaflet/Leaflet/releases/download/v1.8.0/leaflet.zip \
+&& unzip leaflet.zip \
+&& rm leaflet.zip
 
 # Copy update scripts
 COPY openstreetmap-tiles-update-expire.sh /usr/bin/

--- a/leaflet-demo.html
+++ b/leaflet-demo.html
@@ -6,8 +6,8 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="" />
-        <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin=""></script>
+        <link rel="stylesheet" href="leaflet.css"/>
+        <script src="leaflet.js"></script>
 
         <style>
             html, body, #map {


### PR DESCRIPTION
Leaflet 1.8.0	Stable version, released on April 18, 2022.
Leaflet 1.7.1	Previous stable version, released on September 3, 2020.

install leaflet localy so server works offline