### PR TITLE
upgrade carto from v0.18.2 to v1.2.0 (#355)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN pip3 install \
  pyyaml
 
 # Install carto for stylesheet
-RUN npm install -g carto@0.18.2
+RUN npm install -g carto@1.2.0
 
 # Configure Apache
 RUN echo "LoadModule tile_module /usr/lib/apache2/modules/mod_tile.so" >> /etc/apache2/conf-available/mod_tile.conf \


### PR DESCRIPTION
Carto@0.18.2 is not compatible with recent versions of openstreetmap-carto. This makes using custom map styles based on them impossible to use in openstreetmap-tile-server as described in #355. Upgrading carto solves the issue.