### PR TITLE
skip import when persisted data exists

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,7 @@ if [ ! -f /data/style/mapnik.xml ]; then
     carto ${NAME_MML:-project.mml} > mapnik.xml
 fi
 
-if [ "$1" == "import" ]; then
+if [ "$1" == "import" ] && [ ! -f /var/lib/postgresql/14/main/.databaseImported ]; then
     # Ensure that database directory is in right state
     mkdir -p /data/database/postgres/
     chown renderer: /data/database/
@@ -125,6 +125,8 @@ if [ "$1" == "import" ]; then
     sudo -u renderer touch /data/database/planet-import-complete
 
     service postgresql stop
+
+    touch /var/lib/postgresql/14/main/.databaseImported
 
     exit 0
 fi

--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,7 @@ if [ ! -f /data/style/mapnik.xml ]; then
 fi
 
 if [ "$1" == "import" ]; then
-    if [ ! -f /var/lib/postgresql/14/main/.databaseImported ]; then 
+    if [ -f /var/lib/postgresql/14/main/.databaseImported ]; then 
       echo "database already initialized"
       exit 0
     fi

--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,12 @@ if [ ! -f /data/style/mapnik.xml ]; then
     carto ${NAME_MML:-project.mml} > mapnik.xml
 fi
 
-if [ "$1" == "import" ] && [ ! -f /var/lib/postgresql/14/main/.databaseImported ]; then
+if [ "$1" == "import" ]; then
+    if [ ! -f /var/lib/postgresql/14/main/.databaseImported ]; then 
+      echo "database already initialized"
+      exit 0
+    fi
+    
     # Ensure that database directory is in right state
     mkdir -p /data/database/postgres/
     chown renderer: /data/database/


### PR DESCRIPTION
When running in a kubernetes cluster, the import step should usually only happen once.
For example, this could be done using an init container.
Doing so and changing the deployment in a way that triggers a re-deploy currently fails
because the database has already been initialized and persisted.

To avoid this, write an empty file to the postgresql directory and check whether it exists
on the next successful run to avoid running the setup again.

I don't see any downsides to this except wanting to import another region than what already exists. But that would currently fail as well, I believe