### PR TITLE
Update leaflet to 1.9.4 and carto to 5.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,8 +111,10 @@ RUN ln -sf /dev/stdout /var/log/apache2/access.log \
 # leaflet
 COPY leaflet-demo.html /var/www/html/index.html
 RUN cd /var/www/html/ \
-&& wget https://github.com/Leaflet/Leaflet/releases/download/v1.8.0/leaflet.zip \
+&& wget https://github.com/Leaflet/Leaflet/releases/download/v1.9.4/leaflet.zip \
 && unzip leaflet.zip \
+&& mv dist/* . \
+&& rmdir dist \
 && rm leaflet.zip
 
 # Icon

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,8 @@ RUN apt-get update \
 
 FROM compiler-common AS compiler-stylesheet
 RUN cd ~ \
-&& git clone --single-branch --branch v5.4.0 https://github.com/gravitystorm/openstreetmap-carto.git --depth 1 \
+&& git clone --single-branch --branch v5.8.0 https://github.com/gravitystorm/openstreetmap-carto.git --depth 1 \
 && cd openstreetmap-carto \
-&& sed -i 's/, "unifont Medium", "Unifont Upper Medium"//g' style/fonts.mss \
-&& sed -i 's/"Noto Sans Tibetan Regular",//g' style/fonts.mss \
-&& sed -i 's/"Noto Sans Tibetan Bold",//g' style/fonts.mss \
-&& sed -i 's/Noto Sans Syriac Eastern Regular/Noto Sans Syriac Regular/g' style/fonts.mss \
 && rm -rf .git
 
 ###########################################################################################################


### PR DESCRIPTION
This PR updates Leaflet to 1.9.4 and openstreetmap-carto to 5.8.0 and adjusts steps in the Dockerfile as necessary.

This then allows to inject file:// URLs to work around download issues discussed in #244 