### PR TITLE
Add "--break-system-packages" to Docker "pip" command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN wget https://github.com/googlefonts/noto-emoji/blob/9a5261d871451f9b5183c934
 RUN wget https://github.com/stamen/terrain-classic/blob/master/fonts/unifont-Medium.ttf?raw=true --content-disposition -P /usr/share/fonts/
 
 # Install python libraries
-RUN pip3 install \
+RUN pip3 install --break-system-packages \
  requests \
  osmium \
  pyyaml


### PR DESCRIPTION
I'm building a 23.10 based version and they've made changes (either in Ubuntu or in pip, I'm assuming Ubuntu) so that the current pip3 command in the Docker file will fail.  For 24.10, I believe we will need "pip3 install --break-system-packages", and that appears to be safe to use on 22.04 as well.