### PR TITLE
Disable JIT in Postgres settings

### DIFF
--- a/postgresql.custom.conf.tmpl
+++ b/postgresql.custom.conf.tmpl
@@ -22,4 +22,8 @@ track_activity_query_size = 16384
 autovacuum_vacuum_scale_factor = 0.05
 autovacuum_analyze_scale_factor = 0.02
 
+# Disable Postgres JIT
+# https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md#disable-jit
+jit = false
+
 listen_addresses = '*'


### PR DESCRIPTION
Use of PostgreSQL JIT is not recommended. It is enabled by default in PostgreSQL 12 and higher. JIT is benifitial for slow queries where executing the SQL takes substantial time and that time is not spent in function calls. This is not the case for rendering, where most time is spent either fetching from disk, in PostGIS functions, or the query is fast. In theory, the query planner will only use JIT on slower queries, but it is known to get the type of queries map rendering requires wrong.

[More info](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md#disable-jit)